### PR TITLE
#17ArrayListValidation

### DIFF
--- a/src/test/java/com/redhat/insights/expandjsonsmt/ExpandArrayTest.java
+++ b/src/test/java/com/redhat/insights/expandjsonsmt/ExpandArrayTest.java
@@ -50,6 +50,10 @@ public class ExpandArrayTest {
             {
                 "{\"data\": [{\"foo\": \"A\"}, {\"foo\": \"B\"}, {\"foo\": \"C\"}]}",
                 "Struct{obj=Struct{data=[Struct{foo=A}, Struct{foo=B}, Struct{foo=C}]}}"
+            },
+            {
+                "{\"data\": [2146192818, 2146574830, 2147639482]}",
+                "Struct{obj={\"data\": [2146192818, 2146574830, 2147639482]}}"
             }
         });
     }

--- a/src/test/java/com/redhat/insights/expandjsonsmt/ExpandArrayTest.java
+++ b/src/test/java/com/redhat/insights/expandjsonsmt/ExpandArrayTest.java
@@ -52,8 +52,8 @@ public class ExpandArrayTest {
                 "Struct{obj=Struct{data=[Struct{foo=A}, Struct{foo=B}, Struct{foo=C}]}}"
             },
             {
-                "{\"data\": [2146192818, 2146574830, 2147639482]}",
-                "Struct{obj={\"data\": [2146192818, 2146574830, 2147639482]}}"
+                "{\"data\": [1, 2147639482, 2147639482, 2]}",
+                "Struct{obj=Struct{data=[1, 2147639482, 2147639482, 2]}}"
             }
         });
     }


### PR DESCRIPTION
Given message contains an array of values the DataType will be inferred based on value if it's in a particular range.
This breaks the validation where Data type of array elements are expected to be the same.

To reproduce consider following message
 {"data": [2146192818, 2146574830, 2147639482]}"
Where last value Falls under Int64 range so therefor com.redhat.insights.expandjsonsmt.SchemaParser#getArrayElement throws ""Field is not a homogenous array Int32 x Int64"

Proposed PR is to treat all elements the same dataType if at least one has is in higher range, applicable only for Inte32 and 64 at the moment.